### PR TITLE
Speedup collision checking by avoiding expensive sqrt()

### DIFF
--- a/collision.c
+++ b/collision.c
@@ -81,9 +81,9 @@ static struct vector from_xy(struct xy_vector xy)
     float u = xy.x / hexSizeX - 0.5f * xy.y / hexSizeY;
     float v = xy.y / hexSizeY;
     float w = 0.f - u - v;
-    int ui = (int)round(u);
-    int vi = (int)round(v);
-    int wi = (int)round(w);
+    int ui = (int)roundf(u);
+    int vi = (int)roundf(v);
+    int wi = (int)roundf(w);
     // the original code uses double-precision fabs, but since the argument is
     // single-precision, fabsf should return the same result.  it's faster not
     // to have to convert to double and back.
@@ -106,11 +106,11 @@ static struct xy_vector xy_sub(struct xy_vector a, struct xy_vector b)
 }
 static float xy_len(struct xy_vector xy)
 {
-    return (float)sqrt(xy_len2(xy));
+    return sqrtf(xy_len2(xy));
 }
-static float xy_dist(struct xy_vector a, struct xy_vector b)
+static bool check_dist(struct xy_vector a, struct xy_vector b, float dist)
 {
-    return xy_len(xy_sub(a, b));
+    return xy_len2(xy_sub(a, b)) < dist * dist;
 }
 static float to_radians(int32_t r)
 {
@@ -171,8 +171,7 @@ static void mark_area_and_check_board(struct collider_list *list, struct board *
 {
     struct vector p = { u, v };
     struct xy_vector center = to_xy(p);
-    float dist = xy_dist(collider.center, center);
-    if (!(dist < collider.radius + atomRadius))
+    if (!check_dist(collider.center, center, collider.radius + atomRadius))
         return;
     // mark area.  also, this *could* be a collision.
     atom a = mark_used_area(board, p);
@@ -206,7 +205,7 @@ static inline void add_collider(struct collider_list *list, struct board *board,
     board->collision_checks += list->cursor;
     for (size_t i = 0; i < list->cursor; ++i) {
         struct collider other = list->colliders[i];
-        if (!(xy_dist(other.center, collider.center) < other.radius + collider.radius))
+        if (!check_dist(other.center, collider.center, other.radius + collider.radius))
             continue;
         list->collision = true;
         struct vector p = from_xy(collider.center);
@@ -355,7 +354,7 @@ static void resolve_chain_atom_collisions(struct collider_list *list)
                     continue;
                 struct collider b = list->colliders[j];
                 int32_t period = minimum_approach_period(motion_ax, motion_ay, origin_a, b.center);
-                if (xy_dist(b.center, chain_atom_center_for_period(a, period)) < b.radius + atomRadius) {
+                if (check_dist(b.center, chain_atom_center_for_period(a, period), b.radius + atomRadius)) {
                     list->collision = true;
                     if (list->collision_location)
                         *list->collision_location = from_xy(b.center);
@@ -374,7 +373,7 @@ static void resolve_chain_atom_collisions(struct collider_list *list)
             if (!a.in_repeating_segment && !b.in_repeating_segment) {
                 // if neither atom is in a repeating segment, subtracting their motions reduces this to the stationary case.
                 int32_t period = minimum_approach_period(motion_ax - motion_bx, motion_ay - motion_by, origin_a, origin_b);
-                if (xy_dist(chain_atom_center_for_period(a, period), chain_atom_center_for_period(b, period)) < atomRadius + atomRadius) {
+                if (check_dist(chain_atom_center_for_period(a, period), chain_atom_center_for_period(b, period), atomRadius + atomRadius)) {
                     list->collision = true;
                     if (list->collision_location)
                         *list->collision_location = from_xy(chain_atom_center_for_period(a, period));
@@ -419,7 +418,7 @@ static void resolve_chain_atom_collisions(struct collider_list *list)
                         period = k + a.extra_periods;
                     if (!a.in_repeating_segment && b.in_repeating_segment && period < k - b.extra_periods)
                         period = k - b.extra_periods;
-                    if (xy_dist(origin_b_at_period, chain_atom_center_for_period(a, period)) < atomRadius + atomRadius) {
+                    if (check_dist(origin_b_at_period, chain_atom_center_for_period(a, period), atomRadius + atomRadius)) {
                         list->collision = true;
                         if (list->collision_location)
                             *list->collision_location = from_xy(origin_b_at_period);
@@ -445,8 +444,7 @@ static void mark_area_at_infinity_in_direction(struct linear_area_direction *d, 
 {
     struct vector p = { u, v };
     struct xy_vector grid_center = to_xy(p);
-    float dist = xy_dist(center, grid_center);
-    if (!(dist < atomRadius + atomRadius))
+    if (!check_dist(center, grid_center, atomRadius + atomRadius))
         return;
     int32_t period = 0;
     if (d->direction.u != 0)

--- a/sim.h
+++ b/sim.h
@@ -150,7 +150,7 @@ enum mechanism_type {
 
     PROLIFERATION = 1 << 29,
     DIVISION = 1 << 30,
-    REJECTION = 1 << 31,
+    REJECTION = (int)(1u << 31),
 };
 
 static const enum mechanism_type GRABBING_EVERYTHING = 0x3FULL * GRABBING_LOW_BIT;


### PR DESCRIPTION
Test timings show a >5% speedup for large solutions.

----

`sqrt` is a slow function, and should be avoided in performance-sensitive code. This transformation to use `xy_len2` instead saves a noticable amount of time. I also cleaned up a few functions to use the float versions, and fixed a compiler warning.

Here's a comparison of test timings, filtered to those that take more than 0.1 seconds on my machine:

Before:
```
1.16520 C=5092 A=775 test/solution/tourney-2021/Week 6/Steven_/ravaris-rage-OM2021_W6-17.solution
0.52614 C=1981 A=11075 test/solution/tourney-2021/Week 3/winter1703/mist-of-dousing-OM2021_W3-1.solution
6.91026 C=7975 A=72887 test/solution/tourney-2021/Week 3/Mattermonkey/Mattermonkey_-_Cost.solution
0.18461 C=3451 A=2264 test/solution/tourney-2021/Week 3/biggiemac42/mist-of-dousing-OM2021_W3-35.solution
0.11618 C=249 A=2001 test/solution/tourney-2021/Week 3/Steven_/mist-of-dousing-OM2021_W3-8.solution
1.66390 C=3527 A=31530 test/solution/tourney-2021/Week 3/mr_puzzel/mist-of-dousing-OM2021_W3-2.solution
0.62635 C=8971 A=13228 test/solution/tourney-2021/Week 3/Noeuchar/mist-of-dousing-OM2021_W3-3.solution
0.17319 C=3676 A=12803 test/solution/tourney-2021/Week 3/Noeuchar/mist-of-dousing-OM2021_W3-6.solution
0.13075 C=2292 A=12407 test/solution/tourney-2021/Week 3/rolamni/rolamni_OM2021_W3_GC.solution
0.15471 C=1011 A=4347 test/solution/tourney-2021/Week 8/Steven_/elemental-jewel-setting-OM2021_W8-13.solution
0.26335 C=756 A=5785 test/solution/tourney-2021/Week 0/biggiemac42/a-welcome-to-house-colvan-OM2021_W0-6.solution
0.18773 C=897 A=1055 test/solution/tourney-2021/Week 0/biggiemac42/a-welcome-to-house-colvan-OM2021_W0-12.solution
0.24116 C=754 A=5559 test/solution/tourney-2021/Week 0/biggiemac42/a-welcome-to-house-colvan-OM2021_W0-6 (1).solution
0.50058 C=1133 A=5731 test/solution/tourney-2021/Week 0/PentaPig/a-welcome-to-house-colvan-OM2021_W0-1.solution
0.18794 C=960 A=1511 test/solution/tourney-2021/Week 0/PentaPig/a-welcome-to-house-colvan-OM2021_W0-9.solution
0.11721 C=27728 A=68 test/solution/tourney-2021/Week 0/Steven_/a-welcome-to-house-colvan-OM2021_W0-7.solution
0.22888 C=805 A=5394 test/solution/tourney-2021/Week 0/panic/40-805-5394.solution
0.43297 C=1399 A=24547 test/solution/tourney-2021/Week 0/rolamni/rolamni_OM2021_W0_GI.solution
0.50363 C=204 A=13645 test/solution/tourney-2021/Week 0/rolamni/rolamni_OM2021_W0_notrackI.solution
0.25739 C=754 A=5786 test/solution/tourney-2021/Week 0/rolamni/rolamni_OM2021_W0_GC.solution
0.41706 C=427 A=12557 test/solution/tourney-2021/Week 0/rolamni/rolamni_OM2021_W0_GC (1).solution
0.26404 C=757 A=5786 test/solution/tourney-2021/Week 0/Starficz/a-welcome-to-house-colvan-OM2021_W0-4.solution
0.10268 C=3153 A=2058 test/solution/tourney-2019/week2/GA-ShadowCluster.solution
0.59491 C=7577 A=4862 test/solution/jinyou-archive/734_Refined Bronze_B_GAX_NOGIF_60G_7577C_4862A_7577I_8P.solution
0.58280 C=7507 A=4960 test/solution/jinyou-archive/734_Refined Bronze_B_GC_NOGIF_60G_7507C_4960A_7507I_8P.solution
0.15932 C=11453 A=1789 test/solution/tourney-2020/Week 8/Mattermonkey/Mattermonkey_-_1415G_11453_1789.solution
0.10593 C=21359 A=188 test/solution/tourney-2020/Week 8/tw33dl3dee/metal-calculus-tw33dl3dee-no-metric.solution
0.10772 C=34284 A=87 test/solution/tourney-2020/Week 8/tw33dl3dee/metal-calculus-tw33dl3dee-area-87.solution
0.19762 C=140683 A=50 test/solution/tourney-2020/Week 8/PentaPig/output.solution
0.22525 C=157663 A=59 test/solution/tourney-2020/Week 8/jinyou/948_OM2020_W8_MetalCalculus_JINYOU_WASTER_9_AREA_CORRECT_OUT_225G_157663C_59A_3165I_15P (1).solution
0.21379 C=6700 A=600 test/solution/tourney-2020/Week 8/LarsDahl/metal-calculus-OM2020_W8_MetalCalculus-1.solution
0.23540 C=104991 A=108 test/solution/tourney-2020/Week 8/Bambi/metal-calculus-OM2020_W8_MetalCalculus-6.solution
0.21489 C=109276 A=54 test/solution/tourney-2020/Week 8/rolamni/rolamni_OM2020_W8_A.solution
0.15051 C=7661 A=865 test/solution/tourney-2020/Week 8/RP0/metal-calculus-OM2020_W8_MetalCalculus-3.solution
0.59112 C=138691 A=174 test/solution/tourney-2020/Week 0/jinyou/940_OM2020_W0_ConnectTheDots_JINYOU_2310_485G_138691C_174A_80I_24P.solution
```

After:
```
1.04379 C=5092 A=775 test/solution/tourney-2021/Week 6/Steven_/ravaris-rage-OM2021_W6-17.solution
0.49654 C=1981 A=11075 test/solution/tourney-2021/Week 3/winter1703/mist-of-dousing-OM2021_W3-1.solution
6.48372 C=7975 A=72887 test/solution/tourney-2021/Week 3/Mattermonkey/Mattermonkey_-_Cost.solution
0.17469 C=3451 A=2264 test/solution/tourney-2021/Week 3/biggiemac42/mist-of-dousing-OM2021_W3-35.solution
0.11154 C=249 A=2001 test/solution/tourney-2021/Week 3/Steven_/mist-of-dousing-OM2021_W3-8.solution
1.56796 C=3527 A=31530 test/solution/tourney-2021/Week 3/mr_puzzel/mist-of-dousing-OM2021_W3-2.solution
0.59224 C=8971 A=13228 test/solution/tourney-2021/Week 3/Noeuchar/mist-of-dousing-OM2021_W3-3.solution
0.16361 C=3676 A=12803 test/solution/tourney-2021/Week 3/Noeuchar/mist-of-dousing-OM2021_W3-6.solution
0.12350 C=2292 A=12407 test/solution/tourney-2021/Week 3/rolamni/rolamni_OM2021_W3_GC.solution
0.15092 C=1011 A=4347 test/solution/tourney-2021/Week 8/Steven_/elemental-jewel-setting-OM2021_W8-13.solution
0.24868 C=756 A=5785 test/solution/tourney-2021/Week 0/biggiemac42/a-welcome-to-house-colvan-OM2021_W0-6.solution
0.17780 C=897 A=1055 test/solution/tourney-2021/Week 0/biggiemac42/a-welcome-to-house-colvan-OM2021_W0-12.solution
0.22784 C=754 A=5559 test/solution/tourney-2021/Week 0/biggiemac42/a-welcome-to-house-colvan-OM2021_W0-6 (1).solution
0.47136 C=1133 A=5731 test/solution/tourney-2021/Week 0/PentaPig/a-welcome-to-house-colvan-OM2021_W0-1.solution
0.17742 C=960 A=1511 test/solution/tourney-2021/Week 0/PentaPig/a-welcome-to-house-colvan-OM2021_W0-9.solution
0.11363 C=27728 A=68 test/solution/tourney-2021/Week 0/Steven_/a-welcome-to-house-colvan-OM2021_W0-7.solution
0.21611 C=805 A=5394 test/solution/tourney-2021/Week 0/panic/40-805-5394.solution
0.40867 C=1399 A=24547 test/solution/tourney-2021/Week 0/rolamni/rolamni_OM2021_W0_GI.solution
0.47582 C=204 A=13645 test/solution/tourney-2021/Week 0/rolamni/rolamni_OM2021_W0_notrackI.solution
0.24256 C=754 A=5786 test/solution/tourney-2021/Week 0/rolamni/rolamni_OM2021_W0_GC.solution
0.39318 C=427 A=12557 test/solution/tourney-2021/Week 0/rolamni/rolamni_OM2021_W0_GC (1).solution
0.24847 C=757 A=5786 test/solution/tourney-2021/Week 0/Starficz/a-welcome-to-house-colvan-OM2021_W0-4.solution
0.09718 C=3153 A=2058 test/solution/tourney-2019/week2/GA-ShadowCluster.solution
0.56379 C=7577 A=4862 test/solution/jinyou-archive/734_Refined Bronze_B_GAX_NOGIF_60G_7577C_4862A_7577I_8P.solution
0.55238 C=7507 A=4960 test/solution/jinyou-archive/734_Refined Bronze_B_GC_NOGIF_60G_7507C_4960A_7507I_8P.solution
0.15407 C=11453 A=1789 test/solution/tourney-2020/Week 8/Mattermonkey/Mattermonkey_-_1415G_11453_1789.solution
0.10437 C=21359 A=188 test/solution/tourney-2020/Week 8/tw33dl3dee/metal-calculus-tw33dl3dee-no-metric.solution
0.10543 C=34284 A=87 test/solution/tourney-2020/Week 8/tw33dl3dee/metal-calculus-tw33dl3dee-area-87.solution
0.19539 C=140683 A=50 test/solution/tourney-2020/Week 8/PentaPig/output.solution
0.22203 C=157663 A=59 test/solution/tourney-2020/Week 8/jinyou/948_OM2020_W8_MetalCalculus_JINYOU_WASTER_9_AREA_CORRECT_OUT_225G_157663C_59A_3165I_15P (1).solution
0.20676 C=6700 A=600 test/solution/tourney-2020/Week 8/LarsDahl/metal-calculus-OM2020_W8_MetalCalculus-1.solution
0.23298 C=104991 A=108 test/solution/tourney-2020/Week 8/Bambi/metal-calculus-OM2020_W8_MetalCalculus-6.solution
0.21147 C=109276 A=54 test/solution/tourney-2020/Week 8/rolamni/rolamni_OM2020_W8_A.solution
0.14588 C=7661 A=865 test/solution/tourney-2020/Week 8/RP0/metal-calculus-OM2020_W8_MetalCalculus-3.solution
0.57794 C=138691 A=174 test/solution/tourney-2020/Week 0/jinyou/940_OM2020_W0_ConnectTheDots_JINYOU_2310_485G_138691C_174A_80I_24P.solution
```

| | Before | After | After % |
| -- | -- | -- | -- |
| All entries | 30.68476 | 29.19438 | 95.14% |
| >0.1 sec | 18.73517 | 17.67972 | 94.37% |
