### PR TITLE
Loosen restrictions

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -415,7 +415,7 @@ static struct vector decode_position(signed char position[2])
     return (struct vector) { position[0], position[1] };
 }
 
-static char* check_production_constraints(struct solution *solution, struct puzzle_production_info *info)
+static void check_production_constraints(struct solution *solution, struct puzzle_production_info *info)
 {
     for (uint32_t i = 0; i < info->number_of_cabinets; ++i) {
         struct vector *src = get_insides_for_cabinet_type(info->cabinets[i].type);
@@ -430,35 +430,47 @@ static char* check_production_constraints(struct solution *solution, struct puzz
 
     // check conduits
     bool swapped = false;
-    if (solution->number_of_conduits != 2 * info->number_of_conduits)
-        return "solution contains the wrong number of conduits";
-    for (uint32_t i = 0; i < solution->number_of_conduits; ++i) {
-        struct conduit *conduit = &solution->conduits[i];
-        uint32_t conduit_index = conduit->id - 100; // conduit ids start at 100
-        if (conduit_index >= info->number_of_conduits)
-            return "solution contains a conduit not defined in the puzzle file";
+    if (solution->number_of_conduits != 2 * info->number_of_conduits) {
+        solution->cabinet_violations |= CONDUIT_VIOLATED;
+    } else {
+        for (uint32_t i = 0; i < solution->number_of_conduits; ++i) {
+            struct conduit *conduit = &solution->conduits[i];
+            uint32_t conduit_index = conduit->id - 100; // conduit ids start at 100
+            if (conduit_index >= info->number_of_conduits) {
+                solution->cabinet_violations |= CONDUIT_VIOLATED;
+                break;
+            }
 
-        struct puzzle_conduit *puzzle_conduit = &info->conduits[conduit_index];
-        if (conduit->number_of_positions != puzzle_conduit->number_of_hexes)
-            return "solution contains a conduit with an edited shape";
+            struct puzzle_conduit *puzzle_conduit = &info->conduits[conduit_index];
+            if (conduit->number_of_positions != puzzle_conduit->number_of_hexes) {
+                solution->cabinet_violations |= CONDUIT_VIOLATED;
+                break;
+            }
 
-        signed char *starting_position = (i & 1) ? puzzle_conduit->starting_position_b : puzzle_conduit->starting_position_a;
-        uint8_t expected_cabinet = cabinet_for_position(solution, decode_position(starting_position));
+            signed char *starting_position = (i & 1) ? puzzle_conduit->starting_position_b : puzzle_conduit->starting_position_a;
+            uint8_t expected_cabinet = cabinet_for_position(solution, decode_position(starting_position));
 
-        // determine if this conduit is the A-side or the B-side of its pair
-        if ((i & 1) == 0) {
-            struct vector center = solution->glyphs[conduit->glyph_index].position;
-            swapped = cabinet_for_position(solution, center) != expected_cabinet;
-        }
-        struct mechanism *m = &solution->glyphs[swapped ? conduit->other_side_glyph_index : conduit->glyph_index];
+            // determine if this conduit is the A-side or the B-side of its pair
+            if ((i & 1) == 0) {
+                struct vector center = solution->glyphs[conduit->glyph_index].position;
+                swapped = cabinet_for_position(solution, center) != expected_cabinet;
+            }
+            struct mechanism *m = &solution->glyphs[swapped ? conduit->other_side_glyph_index : conduit->glyph_index];
 
-        for (uint32_t j = 0; j < conduit->number_of_positions; ++j) {
-            struct vector pos = conduit->positions[j];
-            if (!vectors_equal(pos, decode_position(puzzle_conduit->hexes[j].offset)))
-                return "solution contains a conduit with an edited shape";
-            pos = mechanism_relative_position(*m, pos.u, pos.v, 1);
-            if (cabinet_for_position(solution, pos) != expected_cabinet)
-                return "solution moved a conduit outside of its original chamber";
+            for (uint32_t j = 0; j < conduit->number_of_positions; ++j) {
+                struct vector pos = conduit->positions[j];
+                if (!vectors_equal(pos, decode_position(puzzle_conduit->hexes[j].offset))) {
+                    solution->cabinet_violations |= CONDUIT_VIOLATED;
+                    break;
+                }
+                pos = mechanism_relative_position(*m, pos.u, pos.v, 1);
+                if (cabinet_for_position(solution, pos) != expected_cabinet) {
+                    solution->cabinet_violations |= CONDUIT_VIOLATED;
+                    break;
+                }
+            }
+            if (solution->cabinet_violations & CONDUIT_VIOLATED)
+                break;
         }
     }
 
@@ -470,8 +482,10 @@ static char* check_production_constraints(struct solution *solution, struct puzz
         const struct vector *footprint = glyph_footprint(m->type);
         for (int j = 0; ; ++j) {
             struct vector pos = mechanism_relative_position(*m, footprint[j].u, footprint[j].v, 1);
-            if (cabinet_for_position(solution, pos) == 0)
-                return "solution contains a glyph outside of the cabinet";
+            if (cabinet_for_position(solution, pos) == 0) {
+                solution->cabinet_violations |= GLYPH_VIOLATED;
+                break;
+            }
             if (vectors_equal(footprint[j], zero_vector))
                 break;
         }
@@ -481,17 +495,23 @@ static char* check_production_constraints(struct solution *solution, struct puzz
     for (uint32_t i = 0; i < solution->number_of_arms; ++i) {
         struct mechanism *m = &solution->arms[i];
         uint8_t base_cabinet = cabinet_for_position(solution, m->position);
-        if (base_cabinet == 0)
-            return "solution contains an arm outside of the cabinet";
+        if (base_cabinet == 0) {
+            solution->cabinet_violations |= ARM_VIOLATED;
+            break;
+        }
         int step = angular_distance_between_grabbers(m->type);
         for (int direction = 0; direction < 6; direction += step) {
             struct vector offset = u_offset_for_direction(direction);
             struct vector pos = mechanism_relative_position(*m, offset.u, offset.v, 1);
             uint8_t cabinet = cabinet_for_position(solution, pos);
-            if (cabinet == 0)
-                return "solution contains an arm outside of the cabinet";
-            else if (cabinet != base_cabinet)
-                return "solution contains an arm reaching across cabinet walls";
+            if (cabinet == 0) {
+                solution->cabinet_violations |= ARM_VIOLATED;
+                break;
+            }
+            else if (cabinet != base_cabinet) {
+                solution->cabinet_violations |= CROSS_WALL_VIOLATED;
+                break;
+            }
         }
     }
 
@@ -500,16 +520,21 @@ static char* check_production_constraints(struct solution *solution, struct puzz
         struct vector position = solution->track_positions[i];
         if (position.u == INT32_MIN && position.v == INT32_MIN)
             continue;
-        if (cabinet_for_position(solution, position) == 0)
-            return "solution contains a track outside of the cabinet";
+        if (cabinet_for_position(solution, position) == 0) {
+            solution->cabinet_violations |= TRACK_VIOLATED;
+            break;
+        }
     }
 
     // check inputs/outputs
     for (uint32_t i = 0; i < solution->number_of_inputs_and_outputs; ++i) {
         struct input_output *io = &solution->inputs_and_outputs[i];
-        for (uint32_t j = 0; j < io->number_of_atoms; ++j)
-            if (cabinet_for_position(solution, io->atoms[j].position) == 0)
-                return "solution contains an input/output outside of the cabinet";
+        for (uint32_t j = 0; j < io->number_of_atoms; ++j) {
+            if (cabinet_for_position(solution, io->atoms[j].position) == 0) {
+                solution->cabinet_violations |= INPUT_OUTPUT_VIOLATED;
+                break;
+            }
+        }
     }
 
     // check isolation
@@ -519,13 +544,13 @@ static char* check_production_constraints(struct solution *solution, struct puzz
             struct input_output *io = &solution->inputs_and_outputs[i];
             uint8_t cabinet = cabinet_for_position(solution, io->atoms->position);
             isolation_data[cabinet] |= io->type;
-            if ((isolation_data[cabinet] & INPUT) && (isolation_data[cabinet] & OUTPUT))
-                return "solution breaks the input/output isolation constraint";
+            if ((isolation_data[cabinet] & INPUT) && (isolation_data[cabinet] & OUTPUT)) {
+                solution->cabinet_violations |= ISOLATION_VIOLATED;
+                break;
+            }
         }
         free(isolation_data);
     }
-
-    return NULL;
 }
 
 static void set_tape(char *tape, int n, int inst, const char **error)
@@ -922,15 +947,9 @@ bool decode_solution(struct solution *solution, struct puzzle_file *pf, struct s
     // production-only pass: enforce production constraints
     if (pf->production_info) {
         solution->production = true;
-        *error = check_production_constraints(solution, pf->production_info);
-        if (*error) {
-            destroy(solution, 0);
-            return false;
-        }
+        check_production_constraints(solution, pf->production_info);
     } else if (solution->number_of_conduits > 0) {
-        *error = "solution contains a conduit not defined in the puzzle file";
-        destroy(solution, 0);
-        return false;
+        solution->cabinet_violations |= CONDUIT_VIOLATED;
     }
     // decode arm tapes in one final pass.  this has to be another pass because
     // reset instructions depend on where track has been placed.

--- a/decode.c
+++ b/decode.c
@@ -323,6 +323,24 @@ static size_t number_of_walls_for_cabinet_type(struct byte_string type)
         return 0;
 }
 
+static struct vector* get_walls_for_cabinet_type(struct byte_string type)
+{
+    if (byte_string_is(type, "Small"))
+        return cabinet_walls_Small;
+    else if (byte_string_is(type, "SmallWide"))
+        return cabinet_walls_SmallWide;
+    else if (byte_string_is(type, "SmallWider"))
+        return cabinet_walls_SmallWider;
+    else if (byte_string_is(type, "Medium"))
+        return cabinet_walls_Medium;
+    else if (byte_string_is(type, "MediumWide"))
+        return cabinet_walls_MediumWide;
+    else if (byte_string_is(type, "Large"))
+        return cabinet_walls_Large;
+    else
+        return 0;
+}
+
 static size_t copy_walls_for_cabinet_type(struct byte_string type, struct vector *dest, int32_t u, int32_t v)
 {
     struct vector *src;
@@ -426,6 +444,14 @@ static void check_production_constraints(struct solution *solution, struct puzzl
             if (u >= 0 && u < CABINET_MAP_SIZE && v >= 0 && v < CABINET_MAP_SIZE)
                 solution->cabinet_map[u][v] = i + 1;
         }
+        src = get_walls_for_cabinet_type(info->cabinets[i].type);
+        n = number_of_walls_for_cabinet_type(info->cabinets[i].type);
+        for (size_t j = 0; j < n; ++j) {
+            int32_t u = info->cabinets[i].position[0] + src[j].u + (CABINET_MAP_SIZE >> 1);
+            int32_t v = info->cabinets[i].position[1] + src[j].v + (CABINET_MAP_SIZE >> 1);
+            if (u >= 0 && u < CABINET_MAP_SIZE && v >= 0 && v < CABINET_MAP_SIZE)
+                solution->cabinet_map[u][v] = 255;
+        }
     }
 
     // check conduits
@@ -482,7 +508,8 @@ static void check_production_constraints(struct solution *solution, struct puzzl
         const struct vector *footprint = glyph_footprint(m->type);
         for (int j = 0; ; ++j) {
             struct vector pos = mechanism_relative_position(*m, footprint[j].u, footprint[j].v, 1);
-            if (cabinet_for_position(solution, pos) == 0) {
+            uint8_t cabinet = cabinet_for_position(solution, pos);
+            if (cabinet == 0 || cabinet == 255) {
                 solution->cabinet_violations |= GLYPH_VIOLATED;
                 break;
             }
@@ -495,7 +522,7 @@ static void check_production_constraints(struct solution *solution, struct puzzl
     for (uint32_t i = 0; i < solution->number_of_arms; ++i) {
         struct mechanism *m = &solution->arms[i];
         uint8_t base_cabinet = cabinet_for_position(solution, m->position);
-        if (base_cabinet == 0) {
+        if (base_cabinet == 0 || base_cabinet == 255) {
             solution->cabinet_violations |= ARM_VIOLATED;
             break;
         }
@@ -504,7 +531,7 @@ static void check_production_constraints(struct solution *solution, struct puzzl
             struct vector offset = u_offset_for_direction(direction);
             struct vector pos = mechanism_relative_position(*m, offset.u, offset.v, 1);
             uint8_t cabinet = cabinet_for_position(solution, pos);
-            if (cabinet == 0) {
+            if (cabinet == 0 || cabinet == 255) {
                 solution->cabinet_violations |= ARM_VIOLATED;
                 break;
             }
@@ -520,7 +547,8 @@ static void check_production_constraints(struct solution *solution, struct puzzl
         struct vector position = solution->track_positions[i];
         if (position.u == INT32_MIN && position.v == INT32_MIN)
             continue;
-        if (cabinet_for_position(solution, position) == 0) {
+        uint8_t cabinet = cabinet_for_position(solution, position);
+        if (cabinet == 0 || cabinet == 255) {
             solution->cabinet_violations |= TRACK_VIOLATED;
             break;
         }
@@ -530,7 +558,8 @@ static void check_production_constraints(struct solution *solution, struct puzzl
     for (uint32_t i = 0; i < solution->number_of_inputs_and_outputs; ++i) {
         struct input_output *io = &solution->inputs_and_outputs[i];
         for (uint32_t j = 0; j < io->number_of_atoms; ++j) {
-            if (cabinet_for_position(solution, io->atoms[j].position) == 0) {
+            uint8_t cabinet = cabinet_for_position(solution, io->atoms[j].position);
+            if (cabinet == 0 || cabinet == 255) {
                 solution->cabinet_violations |= INPUT_OUTPUT_VIOLATED;
                 break;
             }

--- a/decode.c
+++ b/decode.c
@@ -457,19 +457,19 @@ static void check_production_constraints(struct solution *solution, struct puzzl
     // check conduits
     bool swapped = false;
     if (solution->number_of_conduits != 2 * info->number_of_conduits) {
-        solution->cabinet_violations |= CONDUIT_VIOLATED;
+        solution->cabinet_violations |= CONDUIT_ALTERED;
     } else {
         for (uint32_t i = 0; i < solution->number_of_conduits; ++i) {
             struct conduit *conduit = &solution->conduits[i];
             uint32_t conduit_index = conduit->id - 100; // conduit ids start at 100
             if (conduit_index >= info->number_of_conduits) {
-                solution->cabinet_violations |= CONDUIT_VIOLATED;
+                solution->cabinet_violations |= CONDUIT_ALTERED;
                 break;
             }
 
             struct puzzle_conduit *puzzle_conduit = &info->conduits[conduit_index];
             if (conduit->number_of_positions != puzzle_conduit->number_of_hexes) {
-                solution->cabinet_violations |= CONDUIT_VIOLATED;
+                solution->cabinet_violations |= CONDUIT_ALTERED;
                 break;
             }
 
@@ -483,20 +483,19 @@ static void check_production_constraints(struct solution *solution, struct puzzl
             }
             struct mechanism *m = &solution->glyphs[swapped ? conduit->other_side_glyph_index : conduit->glyph_index];
 
+            if (cabinet_for_position(solution, m->position) != expected_cabinet) {
+                solution->cabinet_violations |= CONDUIT_IN_WRONG_CABINET;
+                break;
+            }
+
             for (uint32_t j = 0; j < conduit->number_of_positions; ++j) {
                 struct vector pos = conduit->positions[j];
                 if (!vectors_equal(pos, decode_position(puzzle_conduit->hexes[j].offset))) {
-                    solution->cabinet_violations |= CONDUIT_VIOLATED;
-                    break;
-                }
-                pos = mechanism_relative_position(*m, pos.u, pos.v, 1);
-                if (cabinet_for_position(solution, pos) != expected_cabinet) {
-                    solution->cabinet_violations |= CONDUIT_VIOLATED;
+                    solution->cabinet_violations |= CONDUIT_ALTERED;
                     break;
                 }
             }
-            if (solution->cabinet_violations & CONDUIT_VIOLATED)
-                break;
+
         }
     }
 
@@ -510,7 +509,7 @@ static void check_production_constraints(struct solution *solution, struct puzzl
             struct vector pos = mechanism_relative_position(*m, footprint[j].u, footprint[j].v, 1);
             uint8_t cabinet = cabinet_for_position(solution, pos);
             if (cabinet == 0 || cabinet == 255) {
-                solution->cabinet_violations |= GLYPH_VIOLATED;
+                solution->cabinet_violations |= GLYPH_OUTSIDE_CABINET;
                 break;
             }
             if (vectors_equal(footprint[j], zero_vector))
@@ -523,7 +522,7 @@ static void check_production_constraints(struct solution *solution, struct puzzl
         struct mechanism *m = &solution->arms[i];
         uint8_t base_cabinet = cabinet_for_position(solution, m->position);
         if (base_cabinet == 0 || base_cabinet == 255) {
-            solution->cabinet_violations |= ARM_VIOLATED;
+            solution->cabinet_violations |= ARM_OUTSIDE_CABINET;
             break;
         }
         int step = angular_distance_between_grabbers(m->type);
@@ -532,11 +531,11 @@ static void check_production_constraints(struct solution *solution, struct puzzl
             struct vector pos = mechanism_relative_position(*m, offset.u, offset.v, 1);
             uint8_t cabinet = cabinet_for_position(solution, pos);
             if (cabinet == 0 || cabinet == 255) {
-                solution->cabinet_violations |= ARM_VIOLATED;
+                solution->cabinet_violations |= ARM_OUTSIDE_CABINET;
                 break;
             }
             else if (cabinet != base_cabinet) {
-                solution->cabinet_violations |= CROSS_WALL_VIOLATED;
+                solution->cabinet_violations |= ARM_REACHES_ACROSS_WALL;
                 break;
             }
         }
@@ -549,7 +548,7 @@ static void check_production_constraints(struct solution *solution, struct puzzl
             continue;
         uint8_t cabinet = cabinet_for_position(solution, position);
         if (cabinet == 0 || cabinet == 255) {
-            solution->cabinet_violations |= TRACK_VIOLATED;
+            solution->cabinet_violations |= TRACK_OUTSIDE_CABINET;
             break;
         }
     }
@@ -560,7 +559,7 @@ static void check_production_constraints(struct solution *solution, struct puzzl
         for (uint32_t j = 0; j < io->number_of_atoms; ++j) {
             uint8_t cabinet = cabinet_for_position(solution, io->atoms[j].position);
             if (cabinet == 0 || cabinet == 255) {
-                solution->cabinet_violations |= INPUT_OUTPUT_VIOLATED;
+                solution->cabinet_violations |= INPUT_OUTPUT_OUTSIDE_CABINET;
                 break;
             }
         }
@@ -978,7 +977,7 @@ bool decode_solution(struct solution *solution, struct puzzle_file *pf, struct s
         solution->production = true;
         check_production_constraints(solution, pf->production_info);
     } else if (solution->number_of_conduits > 0) {
-        solution->cabinet_violations |= CONDUIT_VIOLATED;
+        solution->cabinet_violations |= CONDUIT_IN_FREESPACE;
     }
     // decode arm tapes in one final pass.  this has to be another pass because
     // reset instructions depend on where track has been placed.

--- a/decode.h
+++ b/decode.h
@@ -4,6 +4,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define CONDUIT_VIOLATED (1UL << 0)
+#define GLYPH_VIOLATED (1UL << 1)
+#define ARM_VIOLATED (1UL << 2)
+#define CROSS_WALL_VIOLATED (1UL << 3)
+#define INPUT_OUTPUT_VIOLATED (1UL << 4)
+#define TRACK_VIOLATED (1UL << 5)
+#define ISOLATION_VIOLATED (1UL << 6)
+
 struct puzzle_file;
 struct solution;
 struct solution_file;

--- a/decode.h
+++ b/decode.h
@@ -4,13 +4,15 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define CONDUIT_VIOLATED (1UL << 0)
-#define GLYPH_VIOLATED (1UL << 1)
-#define ARM_VIOLATED (1UL << 2)
-#define CROSS_WALL_VIOLATED (1UL << 3)
-#define INPUT_OUTPUT_VIOLATED (1UL << 4)
-#define TRACK_VIOLATED (1UL << 5)
-#define ISOLATION_VIOLATED (1UL << 6)
+#define GLYPH_OUTSIDE_CABINET (1UL << 0)
+#define ARM_OUTSIDE_CABINET (1UL << 1)
+#define ARM_REACHES_ACROSS_WALL (1UL << 2)
+#define INPUT_OUTPUT_OUTSIDE_CABINET (1UL << 3)
+#define TRACK_OUTSIDE_CABINET (1UL << 4)
+#define ISOLATION_VIOLATED (1UL << 5)
+#define CONDUIT_IN_WRONG_CABINET (1UL << 6)
+#define CONDUIT_ALTERED (1UL << 7)
+#define CONDUIT_IN_FREESPACE (1UL << 8)
 
 struct puzzle_file;
 struct solution;

--- a/sim.c
+++ b/sim.c
@@ -834,18 +834,23 @@ static void record_swing_area(struct solution *solution, struct board *board, st
         offset = (struct vector){ offset.u + offset.v, -offset.u };
     int32_t arm_length = abs(offset.u) | abs(offset.v);
     offset = normalize_axis(offset);
+    if (solution->production) {
+        // gripper cabinet wall collisions
+        uint8_t original_cabinet = cabinet_for_position(solution, (struct vector){ base.u + arm_length * offset.u, base.v + arm_length * offset.v});
+        if (cabinet_for_position(solution, (struct vector){ base.u - arm_length * offset.v, base.v + arm_length * (offset.u + offset.v)}) != original_cabinet) {
+            report_collision(board, (struct vector){ base.u - arm_length * offset.v, base.v + arm_length * (offset.u + offset.v)}, "grabber went outside cabinet wall");
+            return;
+        }
+        if (arm_length == 3 && cabinet_for_position(solution, (struct vector){ base.u + 2 * offset.u - 2 * offset.v, base.v + 2 * offset.u + 4 * offset.v }) != original_cabinet) {
+            report_collision(board, (struct vector){ base.u + 2 * offset.u - 2 * offset.v, base.v + 2 * offset.u + 4 * offset.v }, "grabber went outside cabinet wall");
+            return;
+        }
+    }
     switch (arm_length) {
     case 3:
         mark_used_area(board, (struct vector){ base.u + 3 * offset.u - 1 * offset.v, base.v + 1 * offset.u + 4 * offset.v });
         mark_used_area(board, (struct vector){ base.u + 2 * offset.u - 2 * offset.v, base.v + 2 * offset.u + 4 * offset.v });
         mark_used_area(board, (struct vector){ base.u + 1 * offset.u - 3 * offset.v, base.v + 3 * offset.u + 4 * offset.v });
-        // length 3 cabinet wall collision
-        if (solution->production) {
-            if (!cabinet_for_position(solution, (struct vector){ base.u + 2 * offset.u - 2 * offset.v, base.v + 2 * offset.u + 4 * offset.v })) {
-                report_collision(board, (struct vector){ base.u + 2 * offset.u - 2 * offset.v, base.v + 2 * offset.u + 4 * offset.v }, "grabber went outside cabinet wall");
-                return;
-            }
-        }
         // fall through
     case 2:
         mark_used_area(board, (struct vector){ base.u + 2 * offset.u - 1 * offset.v, base.v + 1 * offset.u + 3 * offset.v });
@@ -1394,7 +1399,7 @@ static void mark_arm_area(struct solution *solution, struct board *board)
         int step = angular_distance_between_grabbers(m->type);
         for (int direction = 0; direction < 6; direction += step) {
             struct vector offset = u_offset_for_direction(direction);
-            if (solution->production && !cabinet_for_position(solution, mechanism_relative_position(*m, offset.u, offset.v, 1)))
+            if (solution->production && cabinet_for_position(solution, mechanism_relative_position(*m, offset.u, offset.v, 1)) == 255)
                 report_collision(board, mechanism_relative_position(*m, offset.u, offset.v, 1), "grabber went outside cabinet wall");
             struct vector saved_u = m->direction_u;
             struct vector saved_v = m->direction_v;

--- a/sim.h
+++ b/sim.h
@@ -364,6 +364,8 @@ struct solution {
     // map u,v coordinates => cabinet id + 1 (0 means no cabinet)
     uint8_t cabinet_map[CABINET_MAP_SIZE][CABINET_MAP_SIZE];
 
+    uint32_t cabinet_violations;
+
     // whether it's an input or an output is determined by the type.
     struct input_output *inputs_and_outputs;
     size_t number_of_inputs_and_outputs;

--- a/verifier.c
+++ b/verifier.c
@@ -914,7 +914,19 @@ int verifier_evaluate_metric(void *verifier, const char *metric)
     } else if (!strcmp(metric, "cabinet violations")) {
         int cabinet_violations = solution.cabinet_violations;
         destroy(&solution, &board);
-        return cabinet_violations;
+        if (cabinet_violations == 0) {
+            return 0;
+        } else {
+            return 1;
+        }
+    } else if (!strcmp(metric, "conduit violations")) {
+        int conduit_violations = solution.cabinet_violations & (CONDUIT_ALTERED | CONDUIT_IN_FREESPACE);
+        destroy(&solution, &board);
+        if (conduit_violations == 0) {
+            return 0;
+        } else {
+            return 1;
+        }
     }
     initial_setup(&solution, &board, v->sf->area);
     if (!v->disable_limits)

--- a/verifier.c
+++ b/verifier.c
@@ -911,6 +911,10 @@ int verifier_evaluate_metric(void *verifier, const char *metric)
         int arms = solution.number_of_arms;
         destroy(&solution, &board);
         return arms;
+    } else if (!strcmp(metric, "cabinet violations")) {
+        int cabinet_violations = solution.cabinet_violations;
+        destroy(&solution, &board);
+        return cabinet_violations;
     }
     initial_setup(&solution, &board, v->sf->area);
     if (!v->disable_limits)


### PR DESCRIPTION
- allow simulating solutions which violate typical cabinet restrictions
- make gripper collisions accurate to game, so grippers can exist freely outside cabinets
- add new "cabinet violations" verifier metric; it is 0 when all restrictions are obeyed, otherwise returns a bitfield of violations found